### PR TITLE
Update install step in README to install specific beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 ## Install
 
 ```sh
-expo install onesignal-expo-plugin
+expo install onesignal-expo-plugin@1.0.0-beta3
 ```
 
 **Note:** this does not install the [OneSignal SDK](https://github.com/OneSignal/react-native-onesignal).


### PR DESCRIPTION
Since NPM doesn't automatically recognize the latest beta (with `beta` tag) as the `latest`, we should clarify the install step should specify which beta version to use.