### PR TITLE
Removed the 'external-accessory' background mode

### DIFF
--- a/onesignal/withOneSignalIos.ts
+++ b/onesignal/withOneSignalIos.ts
@@ -33,7 +33,7 @@ const withAppEnvironment: ConfigPlugin<OneSignalPluginProps> = (
 const withRemoteNotificationsPermissions: ConfigPlugin<OneSignalPluginProps> = (
   config
 ) => {
-  const BACKGROUND_MODE_KEYS = ["external-accessory", "remote-notification"];
+  const BACKGROUND_MODE_KEYS = ["remote-notification"];
   return withInfoPlist(config, (newConfig) => {
     if (!Array.isArray(newConfig.modResults.UIBackgroundModes)) {
       newConfig.modResults.UIBackgroundModes = [];


### PR DESCRIPTION
This background mode is not needed for push.