### PR TITLE
Update build script to recreate build directory every time

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./app.plugin.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc",
+    "build": "rm -rf build && tsc",
     "prepare": "yarn run build"
   },
   "repository": {


### PR DESCRIPTION
This avoids accidentally including left-over artifacts in the build directory.