### PR TITLE
Handle no or missing props from app.json

### DIFF
--- a/onesignal/withOneSignalIos.ts
+++ b/onesignal/withOneSignalIos.ts
@@ -81,15 +81,13 @@ const withAppGroupPermissions: ConfigPlugin<OneSignalPluginProps> = (
   });
 };
 
-const withOneSignalNSE: ConfigPlugin<OneSignalPluginProps> = (config, {
-  devTeam,
-}) => {
+const withOneSignalNSE: ConfigPlugin<OneSignalPluginProps> = (config, onesignalProps) => {
   return withXcodeProject(config, async props => {
     xcodeProjectAddNse(
       props.modRequest.projectName || "",
       props.modRequest.platformProjectRoot,
       props.ios?.bundleIdentifier || "",
-      devTeam,
+      onesignalProps?.devTeam,
       "node_modules/onesignal-expo-plugin/build/support/serviceExtensionFiles/"
     );
 
@@ -114,7 +112,7 @@ export function xcodeProjectAddNse(
   appName: string,
   iosPath: string,
   bundleIdentifier: string,
-  devTeam: string,
+  devTeam: string | undefined,
   sourceDir: string
 ): void {
   updatePodfile(iosPath);

--- a/onesignal/withOneSignalIos.ts
+++ b/onesignal/withOneSignalIos.ts
@@ -24,10 +24,17 @@ import { updateNSEEntitlements } from "../support/updateNSEEntitlements";
  */
 const withAppEnvironment: ConfigPlugin<OneSignalPluginProps> = (
   config,
-  { mode }
+  onesignalProps
 ) => {
   return withEntitlementsPlist(config, (newConfig) => {
-    newConfig.modResults["aps-environment"] = mode;
+    if (onesignalProps?.mode == null) {
+      throw new Error(`
+        Missing required "mode" key in your app.json or app.config.js file for "onesignal-expo-plugin".
+        "mode" can be either "development" or "production".
+        Please see onesignal-expo-plugin's README.md for more details.`
+      )
+    }
+    newConfig.modResults["aps-environment"] = onesignalProps.mode;
     return newConfig;
   });
 };


### PR DESCRIPTION
# Description
## One Line Summary
Handles missing props if the app developer does not define them for this plugin in their `app.json` or `app.config.js`.

## Details
### Motivation
Default errors shown to the terminal without this error handling results in not even known which plugin it came from, let alone what to do to fix it.

### Scope
Just handing all external props being `undefined` and considered `nullish` values for keys we read.

# Testing
## Manual testing
Tested these scenarios with a project with `app.json`:

### Ensured an error was shown
#### No props
```json
"plugins": [
      ["onesignal-expo-plugin"]
]
```

#### Props but missing key
```json
"plugins": [
      [ "onesignal-expo-plugin",  {} ]
]
```

### Ensured no error was shown
```json
"plugins": [
      [
        "onesignal-expo-plugin",
        { 
          "mode": "development"
        }
      ]
    ]
```

## Screenshots
### What user see if they are missing props or the key mode
![image (11)](https://user-images.githubusercontent.com/645861/145319031-9d4ab76c-d919-4add-90c4-98a7261970fc.png)

