### PR TITLE
Docs - Add required react-native-onesignal

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ OneSignal.setAppId("YOUR-ONESIGNAL-APP-ID");
 
 ## Run
 ```sh
-$ expo prebuild
+$ expo prebuild --clean
 
 # Build your native iOS project
 $ expo run:ios

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This plugin is an [Expo Config Plugin](https://docs.expo.dev/guides/config-plugi
 
 ```sh
 expo install onesignal-expo-plugin
+yarn add react-native-onesignal
 ```
 
 ## Configuration in app.json / app.config.js


### PR DESCRIPTION
# Description
## One Line Summary
Add required `yarn add react-native-onesignal` and `--clean` parameter to the setup guide so native modules link correctly.

## Related
https://github.com/OneSignal/onesignal-expo-plugin/issues/21#issuecomment-991353625
