### PR TITLE
Make `iPhoneDeploymentTarget` configurable via plugin props

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Welcome to onesignal-expo-plugin 👋</h1>
 <p>
-  <img alt="Version" src="https://img.shields.io/badge/version-1.0.0--beta8-blue.svg?cacheSeconds=2592000" />
+  <img alt="Version" src="https://img.shields.io/badge/version-1.0.0--beta9-blue.svg?cacheSeconds=2592000" />
   <a href="https://github.com/OneSignal/onesignal-expo-plugin#readme" target="_blank">
     <img alt="Documentation" src="https://img.shields.io/badge/documentation-yes-brightgreen.svg" />
   </a>
@@ -47,7 +47,6 @@ Add the plugin to the [plugin array](https://docs.expo.dev/versions/latest/confi
       "onesignal-expo-plugin",
       {
         "mode": "development",
-        "devTeam": "91SW8A37CR"
       }
     ]
   ]
@@ -64,19 +63,21 @@ export default {
     [
       "onesignal-expo-plugin",
       {
-        mode: process.env.NODE_ENV || "development",
-        devTeam: "91SW8A37CR"
+        mode: "development",
       }
     ]
   ]
 };
 ```
 
-#### Plugin Options
-* `mode`: used to configure [APNs environment](https://developer.apple.com/documentation/bundleresources/entitlements/aps-environment) entitlement.
-   - `"development"`
-   - `"production"`
-* `devTeam`: *optional* - used to configure Apple Team ID. You can find your Apple Team ID by running `expo credentials:manager`.
+#### Plugin Prop
+You can pass props to the plugin config object to configure:
+
+| Plugin Prop              |          |                                                                                                                                                                                                                                                                                                                                |
+|--------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `mode`                   | **required** | Used to configure  [APNs environment](https://developer.apple.com/documentation/bundleresources/entitlements/aps-environment)  entitlement.  `"development"` or  `"production"`                                                                                                                                                |
+| `devTeam`                | optional | Used to configure Apple Team ID. You can find your Apple Team ID by running `expo credentials:manager`  e.g: `"91SW8A37CR"`                                                                                                                                                                                                    |
+| `iPhoneDeploymentTarget` | optional | Target `IPHONEOS_DEPLOYMENT_TARGET` value to be used when adding the iOS [NSE](https://documentation.onesignal.com/docs/service-extensions). A deployment target is nothing more than the minimum version of the operating system the application can run on. This value should match the value in your Podfile e.g: `"12.0"`. |
 
 ### OneSignal App ID
 Add your OneSignal App ID to your [Expo constants via the `extra` param](https://docs.expo.dev/versions/latest/config/app/):

--- a/onesignal/withOneSignal.ts
+++ b/onesignal/withOneSignal.ts
@@ -12,8 +12,8 @@ export type OneSignalPluginProps = {
    * (iOS only) Environment name and bundle identifier
    */
   mode: string;
-  iOsBundleIdentifier: string;
   devTeam: string;
+  iPhoneDeploymentTarget: string;
 };
 
 const withOneSignal: ConfigPlugin<OneSignalPluginProps> = (config, props) => {

--- a/onesignal/withOneSignalIos.ts
+++ b/onesignal/withOneSignalIos.ts
@@ -219,7 +219,7 @@ export function xcodeProjectAddNse(
       ) {
         let buildSettingsObj = configurations[key].buildSettings;
         buildSettingsObj.DEVELOPMENT_TEAM = devTeam;
-        buildSettingsObj.IPHONEOS_DEPLOYMENT_TARGET = IPHONEOS_DEPLOYMENT_TARGET;
+        buildSettingsObj.IPHONEOS_DEPLOYMENT_TARGET = iPhoneDeploymentTarget ?? IPHONEOS_DEPLOYMENT_TARGET;
         buildSettingsObj.TARGETED_DEVICE_FAMILY = TARGETED_DEVICE_FAMILY;
         buildSettingsObj.CODE_SIGN_ENTITLEMENTS = `${targetName}/${targetName}.entitlements`;
         buildSettingsObj.CODE_SIGN_STYLE = "Automatic";

--- a/onesignal/withOneSignalIos.ts
+++ b/onesignal/withOneSignalIos.ts
@@ -16,6 +16,14 @@ import { IPHONEOS_DEPLOYMENT_TARGET, TARGETED_DEVICE_FAMILY } from "../support/i
 import { updatePodfile } from "../support/updatePodfile";
 import { updateNSEEntitlements } from "../support/updateNSEEntitlements";
 
+/* I N T E R F A C E S */
+interface PluginOptions {
+  iosPath: string,
+  devTeam?: string,
+  bundleIdentifier?: string,
+  iPhoneDeploymentTarget?: string
+}
+
 // ---------- ---------- ---------- ----------
 
 /**
@@ -83,11 +91,16 @@ const withAppGroupPermissions: ConfigPlugin<OneSignalPluginProps> = (
 
 const withOneSignalNSE: ConfigPlugin<OneSignalPluginProps> = (config, onesignalProps) => {
   return withXcodeProject(config, async props => {
+    const options: PluginOptions = {
+      iosPath: props.modRequest.platformProjectRoot,
+      bundleIdentifier: props.ios?.bundleIdentifier,
+      devTeam: onesignalProps?.devTeam,
+      iPhoneDeploymentTarget: onesignalProps?.iPhoneDeploymentTarget
+    };
+
     xcodeProjectAddNse(
       props.modRequest.projectName || "",
-      props.modRequest.platformProjectRoot,
-      props.ios?.bundleIdentifier || "",
-      onesignalProps?.devTeam,
+      options,
       "node_modules/onesignal-expo-plugin/build/support/serviceExtensionFiles/"
     );
 
@@ -110,11 +123,11 @@ export const withOneSignalIos: ConfigPlugin<OneSignalPluginProps> = (
 
 export function xcodeProjectAddNse(
   appName: string,
-  iosPath: string,
-  bundleIdentifier: string,
-  devTeam: string | undefined,
+  options: PluginOptions,
   sourceDir: string
 ): void {
+  const { iosPath, devTeam, bundleIdentifier, iPhoneDeploymentTarget } = options;
+
   updatePodfile(iosPath);
   updateNSEEntitlements(`group.${bundleIdentifier}.onesignal`)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesignal-expo-plugin",
-  "version": "1.0.0-beta8",
+  "version": "1.0.0-beta9",
   "description": "The OneSignal Expo plugin allows you to use OneSignal without leaving the managed workflow. Developed in collaboration with SweetGreen.",
   "main": "./app.plugin.js",
   "scripts": {

--- a/support/iosConstants.ts
+++ b/support/iosConstants.ts
@@ -1,4 +1,4 @@
-export const IPHONEOS_DEPLOYMENT_TARGET = "10.0";
+export const IPHONEOS_DEPLOYMENT_TARGET = "11.0";
 export const TARGETED_DEVICE_FAMILY = `\"1,2\"`;
 
 export const NSE_PODFILE_SNIPPET = `

--- a/testRuniOS.ts
+++ b/testRuniOS.ts
@@ -11,10 +11,16 @@ import { xcodeProjectAddNse } from "./onesignal/withOneSignalIos";
 //    - If you forget your main target in your Podfile you will get the
 //     "Please add the host targets for the embedded targets to the Podfile." error
 //      even if your .xcodeproj is correct.
+
+const options = {
+  iosPath: '.',
+  bundleIdentifier: "com.onesignal.XcodeTestProj",
+  devTeam: "99SW8E36CT",
+  iPhoneDeploymentTarget: '12.0'
+};
+
 xcodeProjectAddNse(
-    "XcodeTestProj", 
-    ".", 
-    "com.onesignal.XcodeTestProj",
-    "99SW8E36CT",
+    "XcodeTestProj",
+    options,
     "../../repos/onesignal-expo-plugin/support/serviceExtensionFiles/"
-); 
+);


### PR DESCRIPTION
## 1 line description
Adds the ability to configure the iOS Deployment Target via the Expo plugin props.

## Details
As noted in #40  , there is a version mismatch causing problems when attempting to create the Notification Service Extension which was previously hard-set to "10.0". If the project Podfile is set "12.0" for example, the value used by the NSE target should match. These changes introduce a new plugin "prop" that makes this value configurable.