### PR TITLE
Fix: Missing Push Capability on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## April 2022
+### `1.0.1` - 04/11/22
+
+#### Changes
+- Add more info regarding the `expo prebuild` command to README.
+#### Fixes
+- Upstream EAS workaround for "Missing Push Capability on iOS" issue. Adds `aps-environment` entitlement to NSE template. Although it is **not** required in normal builds, there is an upstream limitation from EAS that is resolved by including the push entitlement in both target entitlement files. As of 4/8/22, EAS builds will randomly pick an entitlement file if there are multiple in a project without differentiating among targets. This is resulting in flaky builds where half the time they work and half the time they don't. This can be seen as a temporary fix. Note it carries no side-effects / repercussions (i.e: the entitlement is superfluous but not critical to remove in the future).
+
+## March 2022
+### `1.0.0` - 03/28/22
+
+#### Fixes
+- Upgrade dependencies (via dependabot)
+#### Changes
+- Add credentials guide and update README
+- Advance to General Availability
+
+## February 2022
+### `1.0.0-beta11` - 02/18/2022
+#### Added
+- Linting
+- Instead of creating a "WriterManager", we repurpose the ReaderManager class by renaming it to FileManager and adding a synchronized write helper function (synchronous in the sense that it block further execution until complete).
+- iOS constants file
+
+#### Fixes
+- Import cleanups
+- Linting errors
+- Write safety issu. NSE updater helper functions were previously writing to the entitlements & plist files asynchronously. We should await on each to ensure we don't have multiple writes to the same file at once (which is unsafe).
+
 ## January 2022
 
 ### `1.0.0-beta10` - 01/24/2022

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Welcome to onesignal-expo-plugin 👋</h1>
 <p>
-  <img alt="Version" src="https://img.shields.io/badge/version-1.0.0-blue.svg?cacheSeconds=2592000" />
+  <img alt="Version" src="https://img.shields.io/badge/version-1.0.1-blue.svg?cacheSeconds=2592000" />
   <a href="https://github.com/OneSignal/onesignal-expo-plugin#readme" target="_blank">
     <img alt="Documentation" src="https://img.shields.io/badge/documentation-yes-brightgreen.svg" />
   </a>
@@ -125,11 +125,15 @@ See our [EAS documentation](EAS.md) for help with EAS.
 ### iOS Credentials: OneSignal + EAS
 To distribute your iOS application via EAS, you will need to ensure your credentials are set up correctly. See our [credentials setup guide for instructions](IOS_CREDENTIALS_EAS.md).
 
-## Prebuild
-Since we are using custom native code (via the OneSignal plugin), we need to generate the native runtime code for the project. By prebuilding, we automatically link and configure the native modules that have implemented CocoaPods, autolinking, and other config plugins. You can think of prebuild like a native code bundler.
+## Prebuild (optional)
+Prebuilding in Expo will result in the generation of the native runtime code for the project (and `ios` and `android` directories being built). By prebuilding, we automatically link and configure the native modules that have implemented CocoaPods, autolinking, and other config plugins. You can think of prebuild like a native code bundler.
 
 When you run `expo prebuild` we enter into a custom managed workflow which provides most of the benefits of bare workflows and managed workflows at the same time.
 
+#### Why should I prebuild?
+It may make sense to prebuild locally to inspect config plugin changes and help in debugging issues.
+
+#### Run
 ```sh
 expo prebuild
 ```
@@ -138,6 +142,8 @@ expo prebuild
 # nukes changes and rebuilds
 expo prebuild --clean
 ```
+
+**EAS Note:** if you choose to stay in a fully managed workflow by not prebuilding, EAS will still run `expo prebuild` at build time. You can also prebuild locally but remain in a fully managed workflow by adding the `android` and `ios` directories to your .gitignore.
 
 ## Run
 The following commands will prebuild *and* run your application. Note that for iOS, push notifications will **not** work in the Simulator.

--- a/onesignal/withOneSignal.ts
+++ b/onesignal/withOneSignal.ts
@@ -4,18 +4,9 @@
  */
 
 import { ConfigPlugin } from '@expo/config-plugins';
-import { Mode } from '../types/types';
+import { OneSignalPluginProps } from '../types/types';
 import { withOneSignalAndroid } from './withOneSignalAndroid';
 import { withOneSignalIos } from './withOneSignalIos';
-
-export type OneSignalPluginProps = {
-  /**
-   * (iOS only) Environment name and bundle identifier
-   */
-  mode: Mode;
-  devTeam: string;
-  iPhoneDeploymentTarget: string;
-};
 
 const withOneSignal: ConfigPlugin<OneSignalPluginProps> = (config, props) => {
   config = withOneSignalIos(config, props);

--- a/onesignal/withOneSignal.ts
+++ b/onesignal/withOneSignal.ts
@@ -4,6 +4,7 @@
  */
 
 import { ConfigPlugin } from '@expo/config-plugins';
+import { Mode } from '../types/types';
 import { withOneSignalAndroid } from './withOneSignalAndroid';
 import { withOneSignalIos } from './withOneSignalIos';
 
@@ -11,7 +12,7 @@ export type OneSignalPluginProps = {
   /**
    * (iOS only) Environment name and bundle identifier
    */
-  mode: string;
+  mode: Mode;
   devTeam: string;
   iPhoneDeploymentTarget: string;
 };

--- a/onesignal/withOneSignalAndroid.ts
+++ b/onesignal/withOneSignalAndroid.ts
@@ -6,7 +6,7 @@
 import { ConfigPlugin, withAppBuildGradle } from '@expo/config-plugins';
 import { ONESIGNAL_GRADLE } from '../support/androidConstants';
 import { OneSignalLog } from '../support/OneSignalLog';
-import { OneSignalPluginProps } from './withOneSignal';
+import { OneSignalPluginProps } from '../types/types';
 
 const withGradleBuildConfig: ConfigPlugin<OneSignalPluginProps> = (config) => {
   return withAppBuildGradle(config, (newConfig) => {

--- a/onesignal/withOneSignalIos.ts
+++ b/onesignal/withOneSignalIos.ts
@@ -28,6 +28,7 @@ import { Mode } from "../types/types";
 /* I N T E R F A C E S */
 interface PluginOptions {
   iosPath:                  string,
+  mode:                     Mode,
   devTeam?:                 string,
   bundleVersion?:           string,
   bundleShortVersion?:      string,
@@ -36,7 +37,7 @@ interface PluginOptions {
 }
 
 /**
- * Add 'app-environment' record with current environment to '<project-name>.entitlements' file
+ * Add 'aps-environment' record with current environment to '<project-name>.entitlements' file
  * @see https://documentation.onesignal.com/docs/react-native-sdk-setup#step-4-install-for-ios-using-cocoapods-for-ios-apps
  */
 const withAppEnvironment: ConfigPlugin<OneSignalPluginProps> = (
@@ -109,6 +110,7 @@ const withOneSignalNSE: ConfigPlugin<OneSignalPluginProps> = (config, onesignalP
       devTeam: onesignalProps?.devTeam,
       bundleVersion: props.ios?.buildNumber,
       bundleShortVersion: props?.version,
+      mode: onesignalProps?.mode,
       iPhoneDeploymentTarget: onesignalProps?.iPhoneDeploymentTarget
     };
 
@@ -138,7 +140,7 @@ export function xcodeProjectAddNse(
   options: PluginOptions,
   sourceDir: string
 ): void {
-  const { iosPath, devTeam, bundleIdentifier, bundleVersion, bundleShortVersion, iPhoneDeploymentTarget } = options;
+  const { iosPath, devTeam, bundleIdentifier, bundleVersion, bundleShortVersion, iPhoneDeploymentTarget, mode } = options;
 
   // not awaiting in order to not block main thread
   updatePodfile(iosPath).catch(err => { OneSignalLog.error(err) });
@@ -171,7 +173,7 @@ export function xcodeProjectAddNse(
 
     /* MODIFY COPIED EXTENSION FILES */
     const nseUpdater = new NseUpdaterManager(iosPath);
-    await nseUpdater.updateNSEEntitlements(`group.${bundleIdentifier}.onesignal`)
+    await nseUpdater.updateNSEEntitlements(`group.${bundleIdentifier}.onesignal`, mode)
     await nseUpdater.updateNSEBundleVersion(bundleVersion ?? DEFAULT_BUNDLE_VERSION);
     await nseUpdater.updateNSEBundleShortVersion(bundleShortVersion ?? DEFAULT_BUNDLE_SHORT_VERSION);
 

--- a/onesignal/withOneSignalIos.ts
+++ b/onesignal/withOneSignalIos.ts
@@ -23,6 +23,7 @@ import { updatePodfile } from "../support/updatePodfile";
 import NseUpdaterManager from "../support/NseUpdaterManager";
 import { OneSignalLog } from "../support/OneSignalLog";
 import { FileManager } from "../support/FileManager";
+import { Mode } from "../types/types";
 
 /* I N T E R F A C E S */
 interface PluginOptions {

--- a/onesignal/withOneSignalIos.ts
+++ b/onesignal/withOneSignalIos.ts
@@ -9,7 +9,6 @@ import {
   withInfoPlist,
   withXcodeProject,
 } from "@expo/config-plugins";
-import { OneSignalPluginProps } from "./withOneSignal";
 import * as fs from 'fs';
 import xcode from 'xcode';
 import {
@@ -23,18 +22,7 @@ import { updatePodfile } from "../support/updatePodfile";
 import NseUpdaterManager from "../support/NseUpdaterManager";
 import { OneSignalLog } from "../support/OneSignalLog";
 import { FileManager } from "../support/FileManager";
-import { Mode } from "../types/types";
-
-/* I N T E R F A C E S */
-interface PluginOptions {
-  iosPath:                  string,
-  mode:                     Mode,
-  devTeam?:                 string,
-  bundleVersion?:           string,
-  bundleShortVersion?:      string,
-  bundleIdentifier?:        string,
-  iPhoneDeploymentTarget?:  string
-}
+import { OneSignalPluginProps, PluginOptions } from "../types/types";
 
 /**
  * Add 'aps-environment' record with current environment to '<project-name>.entitlements' file

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesignal-expo-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The OneSignal Expo plugin allows you to use OneSignal without leaving the managed workflow. Developed in collaboration with SweetGreen.",
   "main": "./app.plugin.js",
   "scripts": {

--- a/support/NseUpdaterManager.ts
+++ b/support/NseUpdaterManager.ts
@@ -1,3 +1,4 @@
+import { Mode } from '../types/types';
 import { FileManager } from './FileManager';
 import {
   BUNDLE_SHORT_VERSION_TEMPLATE_REGEX,

--- a/support/NseUpdaterManager.ts
+++ b/support/NseUpdaterManager.ts
@@ -1,6 +1,7 @@
 import { Mode } from '../types/types';
 import { FileManager } from './FileManager';
 import {
+  APS_ENVIRONMENT_MODE,
   BUNDLE_SHORT_VERSION_TEMPLATE_REGEX,
   BUNDLE_VERSION_TEMPLATE_REGEX,
   GROUP_IDENTIFIER_TEMPLATE_REGEX,
@@ -17,9 +18,11 @@ export default class NseUpdaterManager {
     this.nsePath = `${iosPath}/${NSE_TARGET_NAME}`;
   }
 
-  async updateNSEEntitlements(groupIdentifier: string): Promise<void> {
+  async updateNSEEntitlements(groupIdentifier: string, mode: Mode): Promise<void> {
     const entitlementsFilePath = `${this.nsePath}/${entitlementsFileName}`;
     let entitlementsFile = await FileManager.readFile(entitlementsFilePath);
+
+    entitlementsFile = entitlementsFile.replace(APS_ENVIRONMENT_MODE, mode);
     entitlementsFile = entitlementsFile.replace(GROUP_IDENTIFIER_TEMPLATE_REGEX, groupIdentifier);
     await FileManager.writeFile(entitlementsFilePath, entitlementsFile);
   }

--- a/support/iosConstants.ts
+++ b/support/iosConstants.ts
@@ -9,6 +9,7 @@ end`;
 export const NSE_PODFILE_REGEX = /target 'OneSignalNotificationServiceExtension'/;
 
 export const GROUP_IDENTIFIER_TEMPLATE_REGEX = /{{GROUP_IDENTIFIER}}/gm;
+export const APS_ENVIRONMENT_MODE = /{{APS_ENVIRONMENT_MODE}}/gm;
 export const BUNDLE_SHORT_VERSION_TEMPLATE_REGEX = /{{BUNDLE_SHORT_VERSION}}/gm;
 export const BUNDLE_VERSION_TEMPLATE_REGEX = /{{BUNDLE_VERSION}}/gm;
 

--- a/support/serviceExtensionFiles/OneSignalNotificationServiceExtension.entitlements
+++ b/support/serviceExtensionFiles/OneSignalNotificationServiceExtension.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+  <key>aps-environment</key>
+  <string>{{APS_ENVIRONMENT_MODE}}</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>{{GROUP_IDENTIFIER}}</string>

--- a/testRuniOS.ts
+++ b/testRuniOS.ts
@@ -1,4 +1,5 @@
 import { xcodeProjectAddNse } from "./onesignal/withOneSignalIos";
+import { Mode } from "./types/types";
 
 // Quick testing on any Xcode project
 
@@ -14,6 +15,7 @@ import { xcodeProjectAddNse } from "./onesignal/withOneSignalIos";
 
 const options = {
   iosPath: '.',
+  mode: Mode.Dev,
   bundleIdentifier: "com.onesignal.XcodeTestProj",
   devTeam: "99SW8E36CT",
   iPhoneDeploymentTarget: '12.0'

--- a/types/types.ts
+++ b/types/types.ts
@@ -1,0 +1,4 @@
+export enum Mode {
+  Dev = "development",
+  Prod = "production"
+}

--- a/types/types.ts
+++ b/types/types.ts
@@ -1,3 +1,29 @@
+/**
+ * OneSignalPluginProps refer to the properties set by the user in their app config file (e.g: app.json)
+ */
+ export type OneSignalPluginProps = {
+  /**
+   * (iOS only) Environment name and bundle identifier
+   */
+  mode: Mode;
+  devTeam: string;
+  iPhoneDeploymentTarget: string;
+};
+
+/**
+ * Not to be confused with OneSignalPluginProps, PluginOptions are the *internal* properties used by the config plugin
+ * These include a combination of user-defined properties (from OneSignalPluginProps) and other data to pass between functions
+ */
+export type PluginOptions = {
+  iosPath:                  string,
+  mode:                     Mode,
+  devTeam?:                 string,
+  bundleVersion?:           string,
+  bundleShortVersion?:      string,
+  bundleIdentifier?:        string,
+  iPhoneDeploymentTarget?:  string
+}
+
 export enum Mode {
   Dev = "development",
   Prod = "production"


### PR DESCRIPTION
#### Changes
- Add more info regarding the `expo prebuild` command to README.

#### Fixes
- Upstream EAS issue workaround for "Missing Push Capability on iOS" issue. Adds `aps-environment` entitlement to NSE template. Although it is **not** required in normal builds, there is an upstream limitation from EAS that is resolved by including the push entitlement in both target entitlement files. As of 4/8/22, EAS builds will randomly pick an entitlement file if there are multiple in a project without differentiating among targets. This is resulting in flaky builds where half the time they work and half the time they don't. This can be seen as a temporary fix. Note it carries no side-effects / repercussions (i.e: the entitlement is superfluous but not critical to remove in the future).

Fixes #67 