### PR TITLE
support eas build managed credentials

### DIFF
--- a/support/NseUpdaterManager.ts
+++ b/support/NseUpdaterManager.ts
@@ -1,7 +1,5 @@
-import { Mode } from '../types/types';
 import { FileManager } from './FileManager';
 import {
-  APS_ENVIRONMENT_MODE,
   BUNDLE_SHORT_VERSION_TEMPLATE_REGEX,
   BUNDLE_VERSION_TEMPLATE_REGEX,
   GROUP_IDENTIFIER_TEMPLATE_REGEX,
@@ -18,11 +16,10 @@ export default class NseUpdaterManager {
     this.nsePath = `${iosPath}/${NSE_TARGET_NAME}`;
   }
 
-  async updateNSEEntitlements(groupIdentifier: string, mode: Mode): Promise<void> {
+  async updateNSEEntitlements(groupIdentifier: string): Promise<void> {
     const entitlementsFilePath = `${this.nsePath}/${entitlementsFileName}`;
     let entitlementsFile = await FileManager.readFile(entitlementsFilePath);
 
-    entitlementsFile = entitlementsFile.replace(APS_ENVIRONMENT_MODE, mode);
     entitlementsFile = entitlementsFile.replace(GROUP_IDENTIFIER_TEMPLATE_REGEX, groupIdentifier);
     await FileManager.writeFile(entitlementsFilePath, entitlementsFile);
   }

--- a/support/serviceExtensionFiles/OneSignalNotificationServiceExtension.entitlements
+++ b/support/serviceExtensionFiles/OneSignalNotificationServiceExtension.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>aps-environment</key>
-  <string>{{APS_ENVIRONMENT_MODE}}</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>{{GROUP_IDENTIFIER}}</string>


### PR DESCRIPTION
This is an example of how this plugin can be used with managed credentials on eas. This code could probably use some refactor so entitlements/targetName/bundleIdentifier are not defined in 2 places, but I didn't want to integrate too much into the structure of the project, so feel free to merge it as it is or pick some parts of this PR.

Note that this is not 100% fix for entitlements problems, for a proper resolution you need to use the latest expo-cli, server-side fix needs to be deployed in EAS Build (most likely it will land today), new eas-cli version (most likely it will be released today)

related to https://github.com/OneSignal/onesignal-expo-plugin/issues/67