### PR TITLE
Eas build managed credentials support

### DIFF
--- a/onesignal/withOneSignalIos.ts
+++ b/onesignal/withOneSignalIos.ts
@@ -24,6 +24,8 @@ import { OneSignalLog } from "../support/OneSignalLog";
 import { FileManager } from "../support/FileManager";
 import { OneSignalPluginProps, PluginOptions } from "../types/types";
 import assert from 'assert';
+import getEasManagedCredentialsConfigExtra from "../support/eas/getEasManagedCredentialsConfigExtra";
+import { ExpoConfig } from '@expo/config-types';
 
 /**
  * Add 'aps-environment' record with current environment to '<project-name>.entitlements' file
@@ -115,38 +117,9 @@ const withOneSignalNSE: ConfigPlugin<OneSignalPluginProps> = (config, onesignalP
 
 const withEasManagedCredentials: ConfigPlugin<OneSignalPluginProps> = (config) => {
   assert(config.ios?.bundleIdentifier, "Missing 'ios.bundleIdentifier' in app config.")
-  config.extra = {
-    ...config.extra,
-    eas: {
-      ...config.extra?.eas,
-      build: {
-        ...config.extra?.eas?.build,
-        experimental: {
-          ...config.extra?.eas?.build?.experimental,
-          ios: {
-            ...config.extra?.eas?.build?.experimental?.ios,
-            appExtensions: [
-              ...(config.extra?.eas?.build?.experimental?.ios?.appExtensions ?? []),
-              {
-                // keep in sync with native changes in NSE
-                targetName: NSE_TARGET_NAME,
-                bundleIdentifier: `${config.ios.bundleIdentifier}.${NSE_TARGET_NAME}`,
-                entitlements: {
-                  'com.apple.security.application-groups': [
-                    `group.${config.ios.bundleIdentifier}.onesignal`
-                  ]
-                },
-              }
-            ]
-          }
-        }
-      }
-    }
-  }
+  config.extra = getEasManagedCredentialsConfigExtra(config as ExpoConfig);
   return config;
 }
-
-
 
 export const withOneSignalIos: ConfigPlugin<OneSignalPluginProps> = (
   config,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesignal-expo-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The OneSignal Expo plugin allows you to use OneSignal without leaving the managed workflow. Developed in collaboration with SweetGreen.",
   "main": "./app.plugin.js",
   "scripts": {
@@ -24,7 +24,8 @@
   "contributors": [
     "Karen Grigoryan",
     "Rodrigo Gomez-Palacio",
-    "Charlie Cruzan"
+    "Charlie Cruzan",
+    "Wojciech Kozyra"
   ],
   "license": "MIT",
   "bugs": {

--- a/support/NseUpdaterManager.ts
+++ b/support/NseUpdaterManager.ts
@@ -1,7 +1,5 @@
-import { Mode } from '../types/types';
 import { FileManager } from './FileManager';
 import {
-  APS_ENVIRONMENT_MODE,
   BUNDLE_SHORT_VERSION_TEMPLATE_REGEX,
   BUNDLE_VERSION_TEMPLATE_REGEX,
   GROUP_IDENTIFIER_TEMPLATE_REGEX,
@@ -18,11 +16,10 @@ export default class NseUpdaterManager {
     this.nsePath = `${iosPath}/${NSE_TARGET_NAME}`;
   }
 
-  async updateNSEEntitlements(groupIdentifier: string, mode: Mode): Promise<void> {
+  async updateNSEEntitlements(groupIdentifier: string): Promise<void> {
     const entitlementsFilePath = `${this.nsePath}/${entitlementsFileName}`;
     let entitlementsFile = await FileManager.readFile(entitlementsFilePath);
 
-    entitlementsFile = entitlementsFile.replace(APS_ENVIRONMENT_MODE, mode);
     entitlementsFile = entitlementsFile.replace(GROUP_IDENTIFIER_TEMPLATE_REGEX, groupIdentifier);
     await FileManager.writeFile(entitlementsFilePath, entitlementsFile);
   }

--- a/support/eas/getEasManagedCredentialsConfigExtra.ts
+++ b/support/eas/getEasManagedCredentialsConfigExtra.ts
@@ -1,0 +1,33 @@
+import { NSE_TARGET_NAME } from "../iosConstants";
+import { ExpoConfig } from '@expo/config-types';
+
+export default function getEasManagedCredentialsConfigExtra(config: ExpoConfig): {[k: string]: any} {
+  return {
+    ...config.extra,
+    eas: {
+      ...config.extra?.eas,
+      build: {
+        ...config.extra?.eas?.build,
+        experimental: {
+          ...config.extra?.eas?.build?.experimental,
+          ios: {
+            ...config.extra?.eas?.build?.experimental?.ios,
+            appExtensions: [
+              ...(config.extra?.eas?.build?.experimental?.ios?.appExtensions ?? []),
+              {
+                // keep in sync with native changes in NSE
+                targetName: NSE_TARGET_NAME,
+                bundleIdentifier: `${config?.ios?.bundleIdentifier}.${NSE_TARGET_NAME}`,
+                entitlements: {
+                  'com.apple.security.application-groups': [
+                    `group.${config?.ios?.bundleIdentifier}.onesignal`
+                  ]
+                },
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/support/iosConstants.ts
+++ b/support/iosConstants.ts
@@ -9,7 +9,6 @@ end`;
 export const NSE_PODFILE_REGEX = /target 'OneSignalNotificationServiceExtension'/;
 
 export const GROUP_IDENTIFIER_TEMPLATE_REGEX = /{{GROUP_IDENTIFIER}}/gm;
-export const APS_ENVIRONMENT_MODE = /{{APS_ENVIRONMENT_MODE}}/gm;
 export const BUNDLE_SHORT_VERSION_TEMPLATE_REGEX = /{{BUNDLE_SHORT_VERSION}}/gm;
 export const BUNDLE_VERSION_TEMPLATE_REGEX = /{{BUNDLE_VERSION}}/gm;
 

--- a/support/serviceExtensionFiles/OneSignalNotificationServiceExtension.entitlements
+++ b/support/serviceExtensionFiles/OneSignalNotificationServiceExtension.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>aps-environment</key>
-  <string>{{APS_ENVIRONMENT_MODE}}</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>{{GROUP_IDENTIFIER}}</string>


### PR DESCRIPTION
### 1-line summary
Makes use of https://github.com/expo/eas-cli/pull/1039 changes to automatically generate credentials for iOS app extensions.

### Fixes issues with **Multiple capabilities + Managed Credentials** via EAS
The persistent issues from #67 and the workarounds in the [IOS credentials guide](https://github.com/OneSignal/onesignal-expo-plugin/blob/4e01205cebc0633a3d68b73924e2877f2c2836a6/IOS_CREDENTIALS_EAS.md) should be fully resolved with the upstream [CLI fix and release](https://github.com/expo/eas-cli/pull/1078) in [v0.52.0](https://github.com/expo/eas-cli/releases/tag/v0.52.0) and this PR.

Fixes #67

### 1.0.2 Release
