### PR TITLE
Support for monorepos

### DIFF
--- a/onesignal/withOneSignalIos.ts
+++ b/onesignal/withOneSignalIos.ts
@@ -105,10 +105,17 @@ const withOneSignalNSE: ConfigPlugin<OneSignalPluginProps> = (config, onesignalP
       iPhoneDeploymentTarget: onesignalProps?.iPhoneDeploymentTarget
     };
 
+    // support for monorepos where node_modules can be up to 5 parents
+    // above the project directory.
+    let dir = "node_modules"
+    for(let x=0; x < 5 && !FileManager.dirExists(dir); x++) {
+      dir = "../" + dir
+    }
+
     xcodeProjectAddNse(
       props.modRequest.projectName || "",
       options,
-      "node_modules/onesignal-expo-plugin/build/support/serviceExtensionFiles/"
+      dir + "/onesignal-expo-plugin/build/support/serviceExtensionFiles/"
     );
 
     return props;

--- a/support/FileManager.ts
+++ b/support/FileManager.ts
@@ -35,4 +35,8 @@ export class FileManager {
     const fileContents = await FileManager.readFile(path1);
     await FileManager.writeFile(path2, fileContents);
   }
+
+  static dirExists(path: string): boolean {
+    return fs.existsSync(path)
+  }
 }


### PR DESCRIPTION
Look for node_modules in up to 5 parent directories in support of monorepo folder structures