### PR TITLE
Do not use `OneSignalLog.log` in main path

### DIFF
--- a/onesignal/withOneSignalAndroid.ts
+++ b/onesignal/withOneSignalAndroid.ts
@@ -11,7 +11,7 @@ export const withOneSignalAndroid: ConfigPlugin<OneSignalPluginProps> = (
   config,
   props,
 ) => {
-  OneSignalLog.log("No specific actions required for OneSignal on Android...");
-
+  //commented out until https://github.com/expo/eas-cli/issues/1226 is confirmed fixed
+  //OneSignalLog.log("No specific actions required for OneSignal on Android...");
   return config;
 };


### PR DESCRIPTION
Do not use `OneSignal.log` in main path (as it was before) until [expo issue](https://github.com/expo/eas-cli/issues/1226)  has been confirmed as fixed.  `OneSignal.log` uses `console.log` which is problematic during an EAS build.

fixes #111 