### PR TITLE
Specify use_frameworks within OneSignalNotificationServiceExtension target in iOS Podfile

### DIFF
--- a/support/iosConstants.ts
+++ b/support/iosConstants.ts
@@ -4,6 +4,7 @@ export const TARGETED_DEVICE_FAMILY = `"1,2"`;
 export const NSE_PODFILE_SNIPPET = `
 target 'OneSignalNotificationServiceExtension' do
   pod 'OneSignalXCFramework', '>= 3.0', '< 4.0'
+  use_frameworks! :linkage => podfile_properties['ios.useFrameworks'].to_sym if podfile_properties['ios.useFrameworks']
 end`;
 
 export const NSE_PODFILE_REGEX = /target 'OneSignalNotificationServiceExtension'/;


### PR DESCRIPTION
# Description
## One Line Summary
Within `OneSignalNotificationServiceExtension` target, add `use_frameworks` line conditional on `ios.useFrameworks` property existing

## Details
The [BuildProperties Plugin](https://docs.expo.dev/versions/latest/sdk/build-properties/) gives an `useFrameworks` option for iOS which enables `use_frameworks` in the iOS `Podfile` application target.  When specified in the expo app, the OneSignal expo plugin creates a `OneSignalNotificationServiceExtension` target in the `Podfile` that does **not** specify `use_frameworks` in the target.  The build will fail with this inconsistency:

```
<main_app> (true) and OneSignalNotificationServiceExtension (false) do not both set use_frameworks!.
```

This change updates the OneSignal Expo Plugin to specify `use_frameworks` in the `OneSignalNotificationServiceExtension` target when also specified in the app's target.  The line was pulled from the standard `use_frameworks` line that is used on the application target.  It relies on a property that may or may not exist within the `Podfile.properties.json` file.

### Motivation
Fixes #127 

### Scope
There is no runtime changes expected, this change is limited to the building of the iOS app generated by Expo.

# Testing

## Manual testing
After the change was made, a sample application with the following variations were confirmed to build and start up on iOS:
* No BuildProperties plugin.
* BuildProperties plugin with the `useFrameworks` option not specified.
* BuildProperties plugin with the `useFrameworks` option specified.

As this is iOS build specific, android build/run was not evaluated.

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have personally tested this on my device, or explained why that is not possible
   - [x] I have tested this on the latest version of the plugin
   - [x] I have tested this on both Android and iOS, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.