### PR TITLE
use stdlib-provided method to locate plugin dir

### DIFF
--- a/onesignal/withOneSignalIos.ts
+++ b/onesignal/withOneSignalIos.ts
@@ -10,6 +10,7 @@ import {
   withXcodeProject,
 } from "@expo/config-plugins";
 import * as fs from 'fs';
+import * as path from 'path';
 import xcode from 'xcode';
 import {
   DEFAULT_BUNDLE_SHORT_VERSION,
@@ -105,17 +106,13 @@ const withOneSignalNSE: ConfigPlugin<OneSignalPluginProps> = (config, onesignalP
       iPhoneDeploymentTarget: onesignalProps?.iPhoneDeploymentTarget
     };
 
-    // support for monorepos where node_modules can be up to 5 parents
-    // above the project directory.
-    let dir = "node_modules"
-    for(let x=0; x < 5 && !FileManager.dirExists(dir); x++) {
-      dir = "../" + dir
-    }
+    // support for monorepos where node_modules can be above the project directory.
+    const pluginDir = require.resolve("onesignal-expo-plugin/package.json")
 
     xcodeProjectAddNse(
       props.modRequest.projectName || "",
       options,
-      dir + "/onesignal-expo-plugin/build/support/serviceExtensionFiles/"
+      path.join(pluginDir, "../build/support/serviceExtensionFiles/")
     );
 
     return props;


### PR DESCRIPTION
# Description

Updates the `node_modules` locating code to use `require.resolve`, which should support more than 5 levels of nesting and be more reliable than manually checking for `node_modules`.

## Details

### Motivation
Noticed that newer versions of `onesignal-expo-plugin` natively supports monorepos, making our local patch redundant. However I believe that our patch uses a better method to locate the directory so I am submitting it now.

### Scope
What will change: 
- Monorepos with more than five layers of nesting will be supported.

# Testing

## Manual testing
Cloned my fork locally, built it, and tested using `expo prebuild -p ios` with a live app.

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have personally tested this on my device, or explained why that is not possible
   - [x] I have tested this on the latest version of the plugin
   - [x] I have tested this on both Android and iOS, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.