### PR TITLE
Add `ios.buildIdentifier` as a config requirement to using this plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,10 @@ OneSignal.setAppId("YOUR-ONESIGNAL-APP-ID");
 In your configuration file, make sure you set:
 
 | Property             | Details                                                                                                                                                                      |
-|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `version`         | Your app version. Corresponds to `CFBundleShortVersionString` on iOS. This value will be used in your NSE* target's plist file.                                               |
 | `ios.buildNumber` | Build number for your iOS standalone app. Corresponds to `CFBundleVersion` and must match Apple's specified format. This value will be used in your NSE* target's plist file. |
+| `ios.bundleIdentifier` | Bundle identifier for your iOS standalone app. Corresponds to `CFBundleIdentifier`. This value will be used in your NSE* target's plist and entitlements file.           |
 
 \* NSE = Notification Service Extension. Learn more about the NSE [here](https://documentation.onesignal.com/docs/service-extensions).
 


### PR DESCRIPTION
# Description
## One Line Summary
Add `ios.buildIdentifier` as a config requirement to using this plugin.  Fixes #139.

## Details

### Motivation
The README should be sufficiently detailed to ensure a smooth onboarding process.  

# Testing

## Manual testing
No testing was done, this is a documentation update.

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have personally tested this on my device, or explained why that is not possible
   - [x] I have tested this on the latest version of the plugin
   - [x] I have tested this on both Android and iOS, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.