### PR TITLE
Native version update & major release

### DIFF
--- a/onesignal/withOneSignalAndroid.ts
+++ b/onesignal/withOneSignalAndroid.ts
@@ -1,5 +1,5 @@
 /**
- * Expo config plugin for One Signal (Android)
+ * Expo config plugin for OneSignal (Android)
  * @see https://documentation.onesignal.com/docs/react-native-sdk-setup#step-4-install-for-ios-using-cocoapods-for-ios-apps
  */
 
@@ -13,8 +13,8 @@ import { existsSync, mkdirSync, writeFileSync } from 'fs';
 const RESOURCE_ROOT_PATH = 'android/app/src/main/res/';
 
 // The name of each small icon folder resource, and the icon size for that folder.
-const SMALL_ICON_DIRS_TO_SIZE: { [name: string]: number } = { 
-        'drawable-mdpi': 24, 
+const SMALL_ICON_DIRS_TO_SIZE: { [name: string]: number } = {
+        'drawable-mdpi': 24,
         'drawable-hdpi': 36,
         'drawable-xhdpi': 48,
         'drawable-xxhdpi': 72,
@@ -22,7 +22,7 @@ const SMALL_ICON_DIRS_TO_SIZE: { [name: string]: number } = {
   };
 
 // The name of each large icon folder resource, and the icon size for that folder.
-const LARGE_ICON_DIRS_TO_SIZE: { [name: string]: number } = { 
+const LARGE_ICON_DIRS_TO_SIZE: { [name: string]: number } = {
         'drawable-xxxhdpi': 256
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesignal-expo-plugin",
-  "version": "1.3.2",
+  "version": "2.0.0",
   "description": "The OneSignal Expo plugin allows you to use OneSignal without leaving the managed workflow. Developed in collaboration with SweetGreen.",
   "main": "./app.plugin.js",
   "scripts": {
@@ -25,7 +25,8 @@
     "Karen Grigoryan",
     "Rodrigo Gomez-Palacio",
     "Charlie Cruzan",
-    "Wojciech Kozyra"
+    "Wojciech Kozyra",
+    "Brian Smith"
   ],
   "license": "MIT",
   "bugs": {

--- a/support/iosConstants.ts
+++ b/support/iosConstants.ts
@@ -3,7 +3,7 @@ export const TARGETED_DEVICE_FAMILY = `"1,2"`;
 
 export const NSE_PODFILE_SNIPPET = `
 target 'OneSignalNotificationServiceExtension' do
-  pod 'OneSignalXCFramework', '>= 3.0', '< 4.0'
+  pod 'OneSignalXCFramework', '>= 5.0', '< 6.0'
   use_frameworks! :linkage => podfile_properties['ios.useFrameworks'].to_sym if podfile_properties['ios.useFrameworks']
 end`;
 

--- a/support/serviceExtensionFiles/NotificationService.m
+++ b/support/serviceExtensionFiles/NotificationService.m
@@ -1,4 +1,4 @@
-#import <OneSignal/OneSignal.h>
+#import <OneSignalFramework/OneSignalFramework.h>
 
 #import "NotificationService.h"
 


### PR DESCRIPTION
# Description
## One Line Summary
Update native XCFrameworks version range and make major release.

## Details
Makes this plugin compatible with the React Native SDK as they're currently out of sync.

### Motivation
Fixes https://github.com/OneSignal/onesignal-expo-plugin/issues/193
Fixes https://github.com/OneSignal/onesignal-expo-plugin/issues/182

### Scope
- iOS pod version range
- Plugin version number (major release)

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have personally tested this on my device, or explained why that is not possible
   - [x] I have tested this on the latest version of the plugin
   - [x] I have tested this on both Android and iOS, or explained why that is not possible
      - Tested on iOS. No Android related changes.

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.