### PR TITLE
Update import style shown in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Add your OneSignal App ID to your [Expo constants via the `extra` param](https:/
 You can then access the value to pass to the `initialize` function:
 
 ```js
-import OneSignal from 'react-native-onesignal';
+import {OneSignal} from 'react-native-onesignal';
 import Constants from "expo-constants";
 OneSignal.initialize(Constants.expoConfig.extra.oneSignalAppId);
 ```


### PR DESCRIPTION
# Description
## One Line Summary
Updates the import style shown in the README to match the current behavior.

## Details

### Motivation
The wrong import could confuse users who try to implement the SDK.

# Testing

## Manual testing
I installed `react-native-onesignal` 5.0 and `onesignal-expo-plugin` 2.0 and found that importing `OneSignal` direct from the library as I did before gave an undefined error. After consulting more documentation, I changed it to this style and it worked.


# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs