### PR TITLE
fix: #213

### DIFF
--- a/onesignal/withOneSignalIos.ts
+++ b/onesignal/withOneSignalIos.ts
@@ -132,6 +132,11 @@ const withOneSignalNSE: ConfigPlugin<OneSignalPluginProps> = (config, props) => 
         const extFile = NSE_EXT_FILES[i];
         const targetFile = `${iosPath}/${NSE_TARGET_NAME}/${extFile}`;
         await FileManager.copyFile(`${sourceDir}${extFile}`, targetFile);
+
+        if (extFile === 'OneSignalNotificationServiceExtension-Info.plist') {
+          // Copy the plist file to the project root as well
+          await FileManager.copyFile(`${sourceDir}${extFile}`, `${iosPath}/${extFile}`);
+        }
       }
 
       // Copy NSE source file either from configuration-provided location, falling back to the default one.


### PR DESCRIPTION
# Description
## One Line Summary

Temporary fixes on https://github.com/OneSignal/onesignal-expo-plugin/issues/213

## Details

### Motivation
**REQUIRED -** 
Plugin fails to build on `ios` because of mission file.
Related: https://github.com/OneSignal/onesignal-expo-plugin/issues/213


### Scope
**RECOMMEND - OPTIONAL -** What is intended to be effected. What is 
Copy `OneSignalNotificationServiceExtension-Info.plist` file under `ios` dir.

# Testing

## Manual testing
**REQUIRED -** Explain what scenarios were tested and the environment.

<img src="https://github.com/OneSignal/onesignal-expo-plugin/assets/27461460/4fe6513b-d6e1-4335-b384-c3e80f0ef885" width="360"/>

Ensure that `OneSignalNotificationServiceExtension-Info.plist` is also in `ios` dir.


# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have personally tested this on my device, or explained why that is not possible
   - [x] I have tested this on the latest version of the plugin
   - [ ] I have tested this on both Android and iOS, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.