### PR TITLE
PBXGroups: make sure we're only adding to the top-level group

### DIFF
--- a/onesignal/withOneSignalIos.ts
+++ b/onesignal/withOneSignalIos.ts
@@ -166,7 +166,7 @@ const withOneSignalXcodeProject: ConfigPlugin<OneSignalPluginProps> = (config, p
     // files / folder appear in the file explorer in Xcode.
     const groups = xcodeProject.hash.project.objects["PBXGroup"];
     Object.keys(groups).forEach(function(key) {
-      if (groups[key].name === undefined) {
+      if (typeof groups[key] === "object" && groups[key].name === undefined && groups[key].path === undefined) {
         xcodeProject.addToPbxGroup(extGroup.uuid, key);
       }
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesignal-expo-plugin",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "The OneSignal Expo plugin allows you to use OneSignal without leaving the managed workflow. Developed in collaboration with SweetGreen.",
   "main": "./app.plugin.js",
   "scripts": {


### PR DESCRIPTION
# Description
## One Line Summary
Fixes #226 by restricting PBXGroups we add NSE files to.

## Details
Motivation: other groups may have an undefined "name" property other than the top level

Fix #226

### Motivation
In some cases, other PBXGroups can meet the criteria such as "Pods", or "" (un-named) groups. However, we should not add NSE files to these.

# Testing

## Manual testing
Tested manually by creating a beta release (`2.0.3-beta.0`) and running an EAS managed build. However, this introduced a new problem [described here.](https://stackoverflow.com/questions/77815818/expo-49-ios-build-fails-at-xcodebuild-without-any-error-message)

Deleting and recreating 1) Distribution certificates and 2) Provisioning profiles via `eas credentials` did the trick.

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have personally tested this on my device, or explained why that is not possible
   - [x] I have tested this on the latest version of the plugin
   - [x] I have tested this on both Android and iOS, or explained why that is not possible
         - Only impacts iOS

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.