### PR TITLE
Add declaration files to build output

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
         "rootDir": "./",
         "outDir": "./build",
-        "declaration": false
+        "declaration": true
     },
     "include": [
       "./"


### PR DESCRIPTION
<!-- START -->
# READ AND DELETE THIS SECTION BEFORE SUBMITTING PR
* **Fill out each _REQUIRED_ section**
* **Fill out _OPTIONAL_ sections, remove section if it doesn't apply to your PR**
* **Read and fill out each of the checklists below**
* **Remove this section after reading**
<!-- END -->

# Description
## One Line Summary
Add declaration files so I can import types for plugin config

## Details

### Motivation
Currently I do something like this:
```ts
import {
  OneSignalPluginProps as ExpoOneSignalPluginConfig,
  Mode as ExpoOneSignalPluginMode,
} from '@chromeq/onesignal-expo-plugin/build/types/types'; // 👈️ Note `chromeq` is my fork of this repo to let this happen

// The only way currently it can work now is with the following: But Enum for mode won't work and isn't type safe as it comes in an `any` 😢
// import withOneSignalPlugin from 'onesignal-expo-plugin/build/onesignal/withOneSignal';
// type ExpoOneSignalPluginConfig = Parameters<typeof withOneSignalPlugin>[1];

// config 👇️
[
        'onesignal-expo-plugin',
        {
          mode:
            process.env.APP_PROFILE === 'production'
              ? ExpoOneSignalPluginMode.Prod
              : ExpoOneSignalPluginMode.Dev,
        } satisfies ExpoOneSignalPluginConfig, // 👈️ This is now type safe object and I get intellisense
      ],
```

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing

## Testing
   - [x] I have personally tested this on my device, or explained why that is not possible
   - [x] I have tested this on the latest version of the plugin
   - [x] I have tested this on both Android and iOS, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item