### PR TITLE
fix: await updatePodfile to prevent race condition during prebuild

### DIFF
--- a/onesignal/withOneSignalIos.ts
+++ b/onesignal/withOneSignalIos.ts
@@ -106,9 +106,8 @@ const withOneSignalPodfile: ConfigPlugin<OneSignalPluginProps> = (config) => {
   return withDangerousMod(config, [
     'ios',
     async config => {
-      // not awaiting in order to not block main thread
       const iosRoot = path.join(config.modRequest.projectRoot, "ios")
-      updatePodfile(iosRoot).catch(err => { OneSignalLog.error(err) });
+      await updatePodfile(iosRoot);
 
       return config;
     },

--- a/support/updatePodfile.ts
+++ b/support/updatePodfile.ts
@@ -10,10 +10,11 @@ export async function updatePodfile(iosPath: string) {
   if (matches) {
     OneSignalLog.log("OneSignalNotificationServiceExtension target already added to Podfile. Skipping...");
   } else {
-    fs.appendFile(`${iosPath}/Podfile`, NSE_PODFILE_SNIPPET, (err) => {
-      if (err) {
-        OneSignalLog.error("Error writing to Podfile");
-      }
-    })
+    try {
+      fs.appendFileSync(`${iosPath}/Podfile`, NSE_PODFILE_SNIPPET);
+      OneSignalLog.log("OneSignalNotificationServiceExtension target added to Podfile.");
+    } catch (err) {
+      OneSignalLog.error("Error writing to Podfile: " + err);
+    }
   }
 }


### PR DESCRIPTION
## What's happening

When running `npx expo prebuild`, the build randomly fails with:

```
❌ 'OneSignalFramework/OneSignalFramework.h' file not found
```
or
```
❌ 'OneSignalExtension/OneSignalExtension.h' file not found
```

The `OneSignalNotificationServiceExtension` target never gets added to the Podfile before `pod install` runs.

Related issues: https://github.com/OneSignal/onesignal-expo-plugin/issues/231

## Why it happens

Two things are causing this:

### 1. The `updatePodfile` call isn't awaited

In `withOneSignalIos.ts`:

```typescript
// not awaiting in order to not block main thread
const iosRoot = path.join(config.modRequest.projectRoot, "ios")
updatePodfile(iosRoot).catch(err => { OneSignalLog.error(err) });
```

The comment says it's intentional, but this causes prebuild to move on to `pod install` before the Podfile is updated.

### 2. The file write itself is async

In `updatePodfile.ts`:

```typescript
fs.appendFile(`${iosPath}/Podfile`, NSE_PODFILE_SNIPPET, (err) => { ... });
```

Even if we awaited the function, `fs.appendFile` with a callback returns immediately.

## The fix

### `withOneSignalIos.ts`

```diff
- // not awaiting in order to not block main thread
- updatePodfile(iosRoot).catch(err => { OneSignalLog.error(err) });
+ await updatePodfile(iosRoot);
```

### `updatePodfile.ts`

```diff
- fs.appendFile(`${iosPath}/Podfile`, NSE_PODFILE_SNIPPET, (err) => {
-     if (err) {
-         OneSignalLog.error("Error writing to Podfile");
-     }
- });
+ try {
+     fs.appendFileSync(`${iosPath}/Podfile`, NSE_PODFILE_SNIPPET);
+     OneSignalLog.log("OneSignalNotificationServiceExtension target added to Podfile.");
+ } catch (err) {
+     OneSignalLog.error("Error writing to Podfile: " + err);
+ }
```

## Tested with

- onesignal-expo-plugin: 2.0.3
- expo: 53.0.0
- react-native: 0.79.6
- react-native-onesignal: 5.2.16
- Node.js: 22.19.0
- Xcode: 26.0.1

## Before/After

**Before:**
```
$ npx expo prebuild --clean
$ grep "OneSignalNotificationServiceExtension" ios/Podfile
# nothing

$ npx expo run:ios
❌ 'OneSignalExtension/OneSignalExtension.h' file not found
```

**After:**
```
$ npx expo prebuild --clean
onesignal-expo-plugin: OneSignalNotificationServiceExtension target added to Podfile.

$ grep "OneSignalNotificationServiceExtension" ios/Podfile
target 'OneSignalNotificationServiceExtension' do

$ npx expo run:ios
✅ Build succeeds
```