### PR TITLE
chore: rename sdk-actions to sdk-shared

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,6 +17,6 @@ jobs:
     if: |
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.title, 'chore: Release')
-    uses: OneSignal/sdk-actions/.github/workflows/publish-npm-github.yml@main
+    uses: OneSignal/sdk-shared/.github/workflows/publish-npm-github.yml@main
     with:
       branch: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   prep:
-    uses: OneSignal/sdk-actions/.github/workflows/prep-release.yml@main
+    uses: OneSignal/sdk-shared/.github/workflows/prep-release.yml@main
     with:
       target_repo: OneSignal/onesignal-expo-plugin
       version: ${{ inputs.expo_version }}
@@ -28,12 +28,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          # Need repository otherwise caller would set github.repository to the caller itself (e.g. sdk-actions)
+          # Need repository otherwise caller would set github.repository to the caller itself (e.g. sdk-shared)
           repository: OneSignal/onesignal-expo-plugin
           ref: ${{ needs.prep.outputs.release_branch }}
 
       - name: Setup Git User
-        uses: OneSignal/sdk-actions/.github/actions/setup-git-user@main
+        uses: OneSignal/sdk-shared/.github/actions/setup-git-user@main
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -54,9 +54,9 @@ jobs:
 
   create-pr:
     needs: [prep, update_version]
-    uses: OneSignal/sdk-actions/.github/workflows/create-release.yml@main
+    uses: OneSignal/sdk-shared/.github/workflows/create-release.yml@main
     with:
-      # Need target_repo otherwise caller would set github.repository to the caller itself (e.g. sdk-actions)
+      # Need target_repo otherwise caller would set github.repository to the caller itself (e.g. sdk-shared)
       target_repo: OneSignal/onesignal-expo-plugin
       release_branch: ${{ needs.prep.outputs.release_branch }}
       target_branch: ${{ inputs.target_branch }}

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call:
-    uses: OneSignal/sdk-actions/.github/workflows/lint-pr-title.yml@main
+    uses: OneSignal/sdk-shared/.github/workflows/lint-pr-title.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary
Update all GitHub workflow references from `sdk-actions` to `sdk-shared` to reflect the repo rename.

Made with [Cursor](https://cursor.com)