### PR TITLE
feat: add plugin wrapper factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,17 @@ Add the plugin to the **front** of the [plugin array](https://docs.expo.dev/vers
 
 or
 
-**app.config.js**
+**app.config.js/ts**
 
 ```js
+import { oneSignalExpoPlugin } from "onesignal-expo-plugin/plugin";
+
 export default {
   ...
   plugins: [
-    [
-      "onesignal-expo-plugin",
-      {
-        mode: "development",
-      }
-    ]
+    oneSignalExpoPlugin({
+      mode: "development",
+    })
   ]
 };
 ```

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./plugin": {
+      "types": "./dist/plugin.d.ts",
+      "default": "./dist/plugin.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/src/onesignal/plugin.ts
+++ b/src/onesignal/plugin.ts
@@ -1,0 +1,7 @@
+import { name } from "../../package.json";
+import { type OneSignalPluginProps as PluginProps } from "../types/types";
+
+export default (props: PluginProps): [typeof name, PluginProps] => [
+  name,
+  props,
+];

--- a/src/onesignal/plugin.ts
+++ b/src/onesignal/plugin.ts
@@ -1,7 +1,6 @@
 import { name } from "../../package.json";
 import { type OneSignalPluginProps as PluginProps } from "../types/types";
 
-export default (props: PluginProps): [typeof name, PluginProps] => [
-  name,
-  props,
-];
+export const oneSignalExpoPlugin = (
+  props: PluginProps,
+): [typeof name, PluginProps] => [name, props];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,10 @@ export default defineConfig({
     },
   },
   pack: {
-    entry: { index: 'src/onesignal/withOneSignal.ts' },
+    entry: {
+      index: 'src/onesignal/withOneSignal.ts',
+      plugin: 'src/onesignal/plugin.ts',
+    },
     format: 'cjs',
     fixedExtension: false,
     dts: true,


### PR DESCRIPTION
# Description

## One Line Summary

Adds a `plugin` subpath to have a nicer DX and type-safe config props to match expo plugins pattern.

## Details

### AI Summary

> This fork adds a new onesignal-expo-plugin/plugin subpath export with a named oneSignalExpoPlugin factory that returns the `[name, props]` tuple Expo expects, so consumers get typed props instead of writing the raw tuple by hand. The build was updated to emit plugin.js (with types) alongside the main entry, and the README was updated to show the new usage.

### Motivation

When using the `onesignal-expo-plugin` you often don't get intellisense with your props, which forced me to import `OneSignalPluginProps` and use Typescripts `satisfies` to ensure the props match the type.

```ts
import { OneSignalPluginProps } from 'onesignal-expo-plugin';

// plugins...
    [
      'onesignal-expo-plugin',
      {
        devTeam: 'my-team-id',
        mode: process.env.APP_PROFILE === 'production' ? 'production' : 'development',
      } satisfies OneSignalPluginProps,
    ],
```

Expo SDK v56 recently added [type-safe config plugins](https://expo.dev/changelog/sdk-56#type-safe-config-plugins) and I really like the pattern. I updated my local custom plugins to do the same and thought I should help out to do the same here as it is pretty slick imo.

### Scope

Only affects the plugin usage in expo config file. No side effects or changes to anything else.

### OPTIONAL - Other

#### Steps to use

Update import to target: `import { oneSignalExpoPlugin } from 'onesignal-expo-plugin/plugin';`
<img width="786" height="67" alt="image" src="https://github.com/user-attachments/assets/f454dd23-b41b-4351-89e8-cc6d30ac6b03" />

Replace config with plugin function with props:
<img width="714" height="217" alt="image" src="https://github.com/user-attachments/assets/36446c56-7014-414d-b949-eb3a8445caef" />

Showing intellisense showing in VSCode: (note the expo plugins in the same pattern)
<img width="703" height="559" alt="image" src="https://github.com/user-attachments/assets/36850124-58c9-4ddf-96bb-14c23468a96f" />

# Testing

## Manual testing

Published the package under my personal scope and used in my project to manually test app builds work as intended.

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
  - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [x] I have personally tested this on my device, or explained why that is not possible
- [x] I have tested this on the latest version of the plugin
- [x] I have tested this on both Android and iOS, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible.
  - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item
  - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.
