### PR TITLE
feat: [SDK-4728] support disabling location module

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,22 @@ You can pass props to the plugin config object to configure:
 | `appGroupName`           | optional       | Used to configure a custom iOS [App Group](https://documentation.onesignal.com/docs/ios-sdk-setup#step-3-create-an-app-group) name. If not provided, defaults to `"group.{ios.bundleIdentifier}.onesignal"`. e.g: `"group.com.example.myapp.onesignal2"`.                                                                                                                     |
 | `nseBundleIdentifier`    | optional       | Used to configure a custom bundle identifier suffix for the iOS Notification Service Extension. The full bundle identifier will be `"{ios.bundleIdentifier}.{nseBundleIdentifier}"`. If not provided, defaults to `"OneSignalNotificationServiceExtension"`.                                                                                                                  |
 | `disableNSE`             | optional       | If `true`, the iOS Notification Service Extension (NSE) will not be added to the project. The NSE is required for badges, confirmed delivery, media attachments, and action buttons. Only disable this if you only need basic push notifications.                                                                                                                             |
+| `disableLocation`        | optional       | If `true`, the native OneSignal location module will be excluded from iOS and Android builds. Use this if your app does not call `OneSignal.Location` and should not link native location APIs. Android builds must run with `ONESIGNAL_DISABLE_LOCATION=true` in the environment so Gradle can resolve the no-location dependency set.                                       |
 | `sounds`                 | optional       | An array of local paths to custom notification sound files (`.wav` only, ≤30 seconds). Files are copied into the app bundle on iOS and `res/raw/` on Android. e.g: `["./assets/notification_sound.wav"]`. See https://documentation.onesignal.com/docs/customize-notification-sounds.                                                                                         |
 | `liveActivities`         | optional       | Opt in to scaffolding an iOS Widget Extension target for OneSignal Live Activities. Use `{}` for the default `OneSignalWidget` target, or pass `targetName`, `bundleIdentifierSuffix`, `widgetFilePath`, or `deploymentTarget` to customize it. See [Live Activities](#live-activities).                                                                                      |
+
+### Disabling Location
+
+When `disableLocation` is enabled, the plugin writes the iOS Podfile environment
+setting used by `react-native-onesignal` during CocoaPods resolution. For
+Android, make sure the Gradle build also receives the environment variable:
+
+```yaml
+env:
+  ONESIGNAL_DISABLE_LOCATION: true
+```
+
+The value is case-insensitive, and `1` is also accepted.
 
 ### Live Activities
 

--- a/src/onesignal/withOneSignalAndroid.test.ts
+++ b/src/onesignal/withOneSignalAndroid.test.ts
@@ -1,0 +1,36 @@
+import type { ExpoConfig } from 'expo/config';
+import { describe, expect, test, vi } from 'vite-plus/test';
+
+vi.mock('expo/config-plugins', () => ({
+  withDangerousMod: (config: ExpoConfig) => config,
+  withStringsXml: (config: ExpoConfig) => config,
+}));
+
+function makeConfig(): ExpoConfig {
+  return {
+    name: 'TestApp',
+    slug: 'test-app',
+  };
+}
+
+describe('withOneSignalAndroid', () => {
+  test('sets the disable location environment variable when configured', async () => {
+    const { withOneSignalAndroid } = await import('./withOneSignalAndroid');
+    const previousValue = process.env.ONESIGNAL_DISABLE_LOCATION;
+
+    try {
+      withOneSignalAndroid(makeConfig(), {
+        mode: 'production',
+        disableLocation: true,
+      });
+
+      expect(process.env.ONESIGNAL_DISABLE_LOCATION).toBe('true');
+    } finally {
+      if (previousValue == null) {
+        delete process.env.ONESIGNAL_DISABLE_LOCATION;
+      } else {
+        process.env.ONESIGNAL_DISABLE_LOCATION = previousValue;
+      }
+    }
+  });
+});

--- a/src/onesignal/withOneSignalAndroid.ts
+++ b/src/onesignal/withOneSignalAndroid.ts
@@ -15,6 +15,7 @@ import { OneSignalLog } from '../support/OneSignalLog';
 import { OneSignalPluginProps } from '../types';
 
 const RESOURCE_ROOT_PATH = 'android/app/src/main/res/';
+const ONESIGNAL_DISABLE_LOCATION_ENV = 'ONESIGNAL_DISABLE_LOCATION';
 
 // The name of each small icon folder resource, and the icon size for that folder.
 const SMALL_ICON_DIRS_TO_SIZE: { [name: string]: number } = {
@@ -122,6 +123,15 @@ const withSmallIconAccentColor: ConfigPlugin<OneSignalPluginProps> = (config, on
   });
 };
 
+const withLocationModuleEnv: ConfigPlugin<OneSignalPluginProps> = (config, onesignalProps) => {
+  if (onesignalProps.disableLocation == null) {
+    return config;
+  }
+
+  process.env[ONESIGNAL_DISABLE_LOCATION_ENV] = onesignalProps.disableLocation ? 'true' : 'false';
+  return config;
+};
+
 async function saveIconsArrayAsync(
   projectRoot: string,
   icons: string[],
@@ -201,6 +211,7 @@ export const withOneSignalAndroid: ConfigPlugin<OneSignalPluginProps> = (config,
   config = withSmallIcons(config, props);
   config = withLargeIcons(config, props);
   config = withSmallIconAccentColor(config, props);
+  config = withLocationModuleEnv(config, props);
   config = withSoundFiles(config, props);
   return config;
 };

--- a/src/onesignal/withOneSignalIos.ts
+++ b/src/onesignal/withOneSignalIos.ts
@@ -29,7 +29,7 @@ import {
 } from '../support/iosConstants';
 import NseUpdaterManager from '../support/NseUpdaterManager';
 import { OneSignalLog } from '../support/OneSignalLog';
-import { updatePodfile } from '../support/updatePodfile';
+import { updatePodfile, updatePodfileLocationModule } from '../support/updatePodfile';
 import { OneSignalPluginProps } from '../types';
 import { withOneSignalLiveActivity } from './withOneSignalLiveActivity';
 
@@ -127,6 +127,22 @@ const withOneSignalPodfile: ConfigPlugin<OneSignalPluginProps> = (config) => {
     async (config) => {
       const iosRoot = path.join(config.modRequest.projectRoot, 'ios');
       await updatePodfile(iosRoot);
+      return config;
+    },
+  ]);
+};
+
+const withLocationModulePodfile: ConfigPlugin<OneSignalPluginProps> = (config, props) => {
+  const disableLocation = props.disableLocation;
+  if (disableLocation == null) {
+    return config;
+  }
+
+  return withDangerousMod(config, [
+    'ios',
+    async (config) => {
+      const iosRoot = path.join(config.modRequest.projectRoot, 'ios');
+      await updatePodfileLocationModule(iosRoot, disableLocation);
       return config;
     },
   ]);
@@ -317,6 +333,7 @@ const withSoundFiles: ConfigPlugin<OneSignalPluginProps> = (config, onesignalPro
 export const withOneSignalIos: ConfigPlugin<OneSignalPluginProps> = (config, props) => {
   config = withAppEnvironment(config, props);
   config = withRemoteNotificationsPermissions(config, props);
+  config = withLocationModulePodfile(config, props);
   if (!props.disableNSE) {
     config = withCustomAppGroupsKey(config, props);
     config = withAppGroupPermissions(config, props);

--- a/src/support/helpers.test.ts
+++ b/src/support/helpers.test.ts
@@ -97,6 +97,20 @@ describe('validatePluginProps', () => {
     expect(() => validatePluginProps(validProps)).not.toThrow();
   });
 
+  test('accepts disableLocation as true', () => {
+    expect(() => validatePluginProps({ ...validProps, disableLocation: true })).not.toThrow();
+  });
+
+  test('accepts disableLocation as false', () => {
+    expect(() => validatePluginProps({ ...validProps, disableLocation: false })).not.toThrow();
+  });
+
+  test('rejects non-boolean disableLocation', () => {
+    expect(() => validatePluginProps({ ...validProps, disableLocation: 'true' })).toThrow(
+      "'disableLocation' must be a boolean",
+    );
+  });
+
   test('accepts valid 6-digit hex smallIconAccentColor', () => {
     expect(() =>
       validatePluginProps({ ...validProps, smallIconAccentColor: '#FF0000' }),

--- a/src/support/helpers.ts
+++ b/src/support/helpers.ts
@@ -20,6 +20,7 @@ const ONESIGNAL_PLUGIN_PROPS = [
   'appGroupName',
   'nseBundleIdentifier',
   'disableNSE',
+  'disableLocation',
   'sounds',
   'liveActivities',
 ] satisfies (keyof OneSignalPluginProps)[];
@@ -102,6 +103,10 @@ export function validatePluginProps(props: any): void {
 
   if (props.disableNSE !== undefined && typeof props.disableNSE !== 'boolean') {
     throw new Error("OneSignal Expo Plugin: 'disableNSE' must be a boolean.");
+  }
+
+  if (props.disableLocation !== undefined && typeof props.disableLocation !== 'boolean') {
+    throw new Error("OneSignal Expo Plugin: 'disableLocation' must be a boolean.");
   }
 
   if (props.sounds !== undefined) {

--- a/src/support/updatePodfile.test.ts
+++ b/src/support/updatePodfile.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, test } from 'vite-plus/test';
+
+import { updatePodfileLocationModule } from './updatePodfile';
+
+const tempDirs: string[] = [];
+
+async function createIosProject(podfile: string): Promise<string> {
+  const iosPath = await mkdtemp(path.join(tmpdir(), 'onesignal-podfile-'));
+  tempDirs.push(iosPath);
+  await writeFile(path.join(iosPath, 'Podfile'), podfile);
+  return iosPath;
+}
+
+async function readPodfile(iosPath: string): Promise<string> {
+  return readFile(path.join(iosPath, 'Podfile'), 'utf8');
+}
+
+describe('updatePodfileLocationModule', () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  test('adds the disable location flag to the top of the Podfile', async () => {
+    const iosPath = await createIosProject("platform :ios, '15.1'\n");
+
+    await updatePodfileLocationModule(iosPath, true);
+
+    await expect(readPodfile(iosPath)).resolves.toBe(
+      "ENV['ONESIGNAL_DISABLE_LOCATION'] = 'true'\nplatform :ios, '15.1'\n",
+    );
+  });
+
+  test('updates an existing disable location flag', async () => {
+    const iosPath = await createIosProject(
+      "ENV['ONESIGNAL_DISABLE_LOCATION'] = 'true'\nplatform :ios, '15.1'\n",
+    );
+
+    await updatePodfileLocationModule(iosPath, false);
+
+    await expect(readPodfile(iosPath)).resolves.toBe(
+      "ENV['ONESIGNAL_DISABLE_LOCATION'] = 'false'\nplatform :ios, '15.1'\n",
+    );
+  });
+
+  test('migrates the legacy disable location Podfile global', async () => {
+    const iosPath = await createIosProject(
+      "$OneSignalDisableLocation = true\nplatform :ios, '15.1'\n",
+    );
+
+    await updatePodfileLocationModule(iosPath, true);
+
+    await expect(readPodfile(iosPath)).resolves.toBe(
+      "ENV['ONESIGNAL_DISABLE_LOCATION'] = 'true'\nplatform :ios, '15.1'\n",
+    );
+  });
+});

--- a/src/support/updatePodfile.ts
+++ b/src/support/updatePodfile.ts
@@ -4,6 +4,10 @@ import { FileManager } from './FileManager';
 import { NSE_TARGET_NAME, NSE_PODFILE_REGEX, NSE_PODFILE_SNIPPET } from './iosConstants';
 import { OneSignalLog } from './OneSignalLog';
 
+const ONESIGNAL_DISABLE_LOCATION_ENV = "ENV['ONESIGNAL_DISABLE_LOCATION']";
+const ONESIGNAL_DISABLE_LOCATION_REGEX =
+  /^(?:ENV\[['"]ONESIGNAL_DISABLE_LOCATION['"]\]\s*=\s*['"](true|false)['"]|\$OneSignalDisableLocation\s*=\s*(true|false))\s*$/m;
+
 export async function updatePodfile(iosPath: string) {
   const podfile = await FileManager.readFile(`${iosPath}/Podfile`);
   const matches = podfile.match(NSE_PODFILE_REGEX);
@@ -15,4 +19,17 @@ export async function updatePodfile(iosPath: string) {
 
   await fs.appendFile(`${iosPath}/Podfile`, NSE_PODFILE_SNIPPET);
   OneSignalLog.log(`${NSE_TARGET_NAME} target added to Podfile.`);
+}
+
+export async function updatePodfileLocationModule(iosPath: string, disableLocation: boolean) {
+  const podfilePath = `${iosPath}/Podfile`;
+  const podfile = await FileManager.readFile(podfilePath);
+  const nextValue = `${ONESIGNAL_DISABLE_LOCATION_ENV} = '${disableLocation ? 'true' : 'false'}'`;
+
+  if (ONESIGNAL_DISABLE_LOCATION_REGEX.test(podfile)) {
+    await fs.writeFile(podfilePath, podfile.replace(ONESIGNAL_DISABLE_LOCATION_REGEX, nextValue));
+    return;
+  }
+
+  await fs.writeFile(podfilePath, `${nextValue}\n${podfile}`);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,12 @@ export type OneSignalPluginProps = {
   disableNSE?: boolean;
 
   /**
+   * (optional) If true, the native OneSignal location module will be excluded from iOS and Android builds.
+   * OneSignal.Location APIs will not collect location and will no-op or return false.
+   */
+  disableLocation?: boolean;
+
+  /**
    * (optional) An array of local paths to custom notification sound files (.wav only).
    * Files are added to the iOS app bundle and Android res/raw/.
    * @see https://documentation.onesignal.com/docs/customize-notification-sounds


### PR DESCRIPTION
# Description

## One Line Summary

Adds a `disableLocation` Expo plugin option for excluding the native OneSignal location module.

## Details

### Motivation

React Native OneSignal now supports excluding the native location dependency when apps do not use `OneSignal.Location`. Expo apps need a plugin-level option so generated native projects can opt into the same no-location dependency set.

### Scope

This adds `disableLocation` to the plugin props, validates it as a boolean, writes the iOS Podfile environment setting used during CocoaPods resolution, and seeds the Android build environment used by Gradle resolution. It also documents the option and adds unit coverage for the Android env setup and Podfile updates.

# Testing

## Manual testing

- Ran `vp test`: 9 test files passed, 76 tests passed
- Ran `vp check`: formatting passed, but existing issues remain in unrelated examples (`examples/demo/src/hooks/useOneSignal.ts`, `examples/demo/src/screens/HomeScreen.tsx`, and `examples/disable-nse/app.config.ts`)
- Validated during local no-location demo testing that Android dependency resolution with `ONESIGNAL_DISABLE_LOCATION=true` excludes `com.onesignal:location`

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [x] I have personally tested this on my device, or explained why that is not possible
- [x] I have tested this on the latest version of the plugin
- [x] I have tested this on both Android and iOS, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)