### PR TITLE
chore: automate Expo release version detection

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       expo_version:
-        description: 'New OneSignal Expo Plugin Version (e.g., 2.1.0 or 2.1.0-beta.1)'
-        required: true
+        description: 'Override the auto-detected version (e.g., 2.1.0 or 2.1.0-beta.1). Leave blank to auto-detect.'
+        required: false
         type: string
       target_branch:
         description: 'Target branch to create the release PR on. Defaults to main.'
@@ -14,15 +14,33 @@ on:
         default: main
 
 jobs:
+  determine_version:
+    runs-on: ubuntu-latest
+    outputs:
+      expo_version: ${{ inputs.expo_version || steps.next_version.outputs.version }}
+      release_needed: ${{ inputs.expo_version != '' || steps.next_version.outputs.release-needed == 'true' }}
+
+    steps:
+      - name: Determine OneSignal Expo Plugin version
+        if: github.event_name == 'workflow_dispatch' && inputs.expo_version == ''
+        id: next_version
+        uses: OneSignal/sdk-shared/.github/actions/determine-next-version@main
+        with:
+          github-token: ${{ secrets.GH_PUSH_TOKEN || github.token }}
+          target-repo: OneSignal/onesignal-expo-plugin
+          target-branch: ${{ inputs.target_branch }}
+
   prep:
+    needs: determine_version
+    if: needs.determine_version.outputs.release_needed == 'true'
     uses: OneSignal/sdk-shared/.github/workflows/prep-release.yml@main
     with:
       target_repo: OneSignal/onesignal-expo-plugin
-      version: ${{ inputs.expo_version }}
+      version: ${{ needs.determine_version.outputs.expo_version }}
 
   # Expo Plugin specific steps
   update_version:
-    needs: prep
+    needs: [determine_version, prep]
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -42,9 +60,9 @@ jobs:
         uses: OneSignal/sdk-shared/.github/actions/setup-git-user@main
 
       - name: Update sdk version
+        env:
+          NEW_VERSION: ${{ needs.determine_version.outputs.expo_version }}
         run: |
-          NEW_VERSION="${{ inputs.expo_version }}"
-
           # Update package.json version
           npm pkg set version="$NEW_VERSION"
 


### PR DESCRIPTION
# Description

## One Line Summary

Automatically detect the next Expo plugin release version while retaining an optional manual override.

## Details

### Motivation

Remove the need to manually determine and enter every release version, matching the release workflow used by the Flutter SDK.

### Scope

Updates only the create-release PR workflow. It detects whether a release is needed, passes the resolved version through release preparation and version updates, and skips release work when no release is needed. No public API or runtime behavior changes.

# Testing

## Manual testing

- `git diff --check` passed.
- The pre-commit `vp check --fix` task passed.
- Device, Android, and iOS testing do not apply because this change only affects GitHub Actions release orchestration and cannot be fully executed locally.

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [x] I have personally tested this on my device, or explained why that is not possible
- [x] I have tested this on the latest version of the plugin
- [x] I have tested this on both Android and iOS, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)